### PR TITLE
If no .min file present for a component when using --min, concat regular version.

### DIFF
--- a/bowcat.js
+++ b/bowcat.js
@@ -75,6 +75,10 @@ function constructFileList (dir, mains, minified) {
     return include;
   });
 
+  if (minified && files.length === 0) {
+    return constructFileList(dir, mains, false);
+  }
+
   return files;
 }
 


### PR DESCRIPTION
Hi there,

I'm a student at Nashville Software School and our instructor introduced bowcat to us for taking care of our bower dependencies during deployment.

He had us using the --min option, which led to problems with the Firebase bower package since it has no "firebase.min.js" file/version, only "firebase.js". 

As bowcat is currently written, it will omit Firebase from /lib/build.js when using --min since it will not find any firebase.min.js file.

To address this, I added an if statement toward the end of the constructFileList function such that if the user is using the --min option, and constructFileList is about to return an empty "files" array (ie, it couldn't find any .min files for the package), it will rerun constructFileList with the minified parameter set to false. So if it finds no suitable .min files for a particular package, it will go back and add a non-minified version(s), essentially.

Thank you for your time and for bowcat!
