### PR TITLE
Dropped rimraf.

### DIFF
--- a/bowcat.js
+++ b/bowcat.js
@@ -7,7 +7,6 @@ var path = require('path');
 var fs = require('fs');
 
 var _ = require('lodash');
-var rimraf = require('rimraf');
 var json = require('bower-json');
 var bowerDirectory = require('bower-directory');
 var debug = require('debug')('bowcat');
@@ -143,9 +142,15 @@ function concatPackage (pack, outDir, minified) {
 function concatPackages (packages, outDir, minified) {
   if (! outDir) outDir = path.join('.', 'build');
 
-  if (fs.existsSync(outDir)) rimraf.sync(outDir);
-  fs.mkdirSync(outDir);
-
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+  var jsFileName = path.join(outDir, 'build.js');
+  if (fs.existsSync(jsFileName)){
+    fs.truncateSync(jsFileName, 0);
+  }
+  var cssFileName = path.join(outDir, 'build.css');
+  if (fs.existsSync(cssFileName)){
+    fs.truncateSync(cssFileName, 0);
+  }
   _.each(packages, function (pack, i, l) {
     concatPackage(pack, outDir, minified);
   });

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "bower-json": "^0.4.0",
     "debug": "2.0.0",
     "lodash": "2.4.1",
-    "minimist": "1.1.0",
-    "rimraf": "2.2.8"
+    "minimist": "1.1.0"
   },
   "devDependencies": {
     "should": "4.0.4",


### PR DESCRIPTION
Instead of deleting the output directory, check if the output files already exist and truncate them to 0 bytes.

It just seems strange to nuke a whole folder, which may potentially contain other generated files, when simply truncating the output files will do the job.
